### PR TITLE
docs(api): update mock api host

### DIFF
--- a/mockApi/DOC.md
+++ b/mockApi/DOC.md
@@ -1,16 +1,22 @@
 # Mock API Documentation
+
 ​
-The Mock API is a stub backend for the Lalamove Frontend challenge, and served at [https://mock-api.dev.lalamove.com](https://mock-api.dev.lalamove.com).
+The Mock API is a stub backend for the Lalamove Frontend challenge, and served at [https://sg-mock-api.lalamove.com](https://sg-mock-api.lalamove.com).
 You are welcome to boot it up in your local machine.
 ​
+
 ## APIs
+
 ​
 The actual API you should integrate with Lalamove Frontend challenge.
 ​
+
 ### POST /route
+
 ​
 Submit a routing request to the backend for processing.
 ​
+
 ```js
 /**
  * @api {POST} /route
@@ -21,29 +27,33 @@ Submit a routing request to the backend for processing.
  * @apiSuccessExample {json} Success Response
  *    HTTP/1.1 200 OK
  *    { "token": "9d3503e0-7236-4e47-a62f-8b01b5646c16" }
- * 
+ *
  * @apiErrorExample {String} Error Response:
- *    HTTP/1.1 500 Internal Server Error 
+ *    HTTP/1.1 500 Internal Server Error
  *    Internal Server Error
- * 
+ *
  * @apiExample {curl} Example Usage:
  *  curl --request POST \
       --header 'Content-Type: application/json' \
       --data '{"origin":"Innocentre, Hong Kong","destination":"Hong Kong International Airport Terminal 1"}' \
-      --url https://mock-api.dev.lalamove.com/route
+      --url https://sg-mock-api.lalamove.com/route
  * /
 ```
+
 ​
+
 ### GET /route/:token
+
 ​
 Gets the route from the request identified by the processing token from `POST /route`.
 ​
+
 ```js
 /**
  * @api {GET} /route/:token
  * @apiParam {String} token Refers to the processing token returned from the `/route` endpoint.
- * 
- * @apiSuccess (Busy) {String} status Current status of the route request on the backend. 
+ *
+ * @apiSuccess (Busy) {String} status Current status of the route request on the backend.
  * @apiSuccessExample (Busy) {json}
  *    HTTP/1.1 200 OK
  *    { "status": "in progress" }
@@ -73,46 +83,63 @@ Gets the route from the request identified by the processing token from `POST /r
  *      "total_distance": 20000,
  *      "total_time": 1800
  *    }
- * 
+ *
  * @apiErrorExample {String} Error Response:
- *    HTTP/1.1 500 Internal Server Error 
+ *    HTTP/1.1 500 Internal Server Error
  *    Internal Server Error
- * 
+ *
  * @apiExample {curl} Example Usage:
  *  curl --request GET \
-     --url https://mock-api.dev.lalamove.com/route/9d3503e0-7236-4e47-a62f-8b01b5646c16
+     --url https://sg-mock-api.lalamove.com/route/9d3503e0-7236-4e47-a62f-8b01b5646c16
  * /
 ```
+
 ​
+
 ## APIs (for testing purposes)
+
 ​
 These are endpoints with deterministic responses to help with your development.
 ​
+
 ### POST /mock/route/500
+
 ```
-HTTP/1.1 500 Internal Server Error 
+HTTP/1.1 500 Internal Server Error
 Internal Server Error
 ```
+
 ​
+
 ### POST /mock/route/success
+
 ```
 HTTP/1.1 200 OK
 { "token": "9d3503e0-7236-4e47-a62f-8b01b5646c16" }
 ```
+
 ​
+
 ### GET /mock/route/500
+
 ```
-HTTP/1.1 500 Internal Server Error 
+HTTP/1.1 500 Internal Server Error
 Internal Server Error
 ```
+
 ​
+
 ### GET /mock/route/inprogress
+
 ```
 HTTP/1.1 200 OK
 { "status": "in progress" }
 ```
+
 ​
+
 ### GET /mock/route/failure
+
 ```
 HTTP/1.1 200 OK
 {
@@ -120,8 +147,11 @@ HTTP/1.1 200 OK
   "error": "Location not accessible by car"
 }
 ```
+
 ​
+
 ### GET /mock/route/success
+
 ```
 HTTP/1.1 200 OK
 {


### PR DESCRIPTION
### Why

`https://mock-api.dev.lalamove.com` has been decommissioned.

### What

- we have re-hosted the tech challenge API to `https://sg-mock-api.lalamove.com`
- change all references of `https://mock-api.dev.lalamove.com` to `https://sg-mock-api.lalamove.com`